### PR TITLE
fix(nix): remove Spotlight indexing exclusion for /nix

### DIFF
--- a/nix-darwin/modules/system/default.nix
+++ b/nix-darwin/modules/system/default.nix
@@ -4,12 +4,6 @@
   ## Core system
   nixpkgs.hostPlatform = "aarch64-darwin";
   system.stateVersion = 6;
-  
-  system.activationScripts.postActivation.text = ''
-    printf "Disabling Spotlight on /nix... "
-    touch /nix/.metadata_never_index
-    echo "ok"
-  '';
 
   ## Nix settings
   # Let Determinate Nix handle Nix configuration


### PR DESCRIPTION
Remove activation script that disabled Spotlight indexing on /nix directory. This allows Spotlight to index the Nix store for better searchability.

🤖 Generated with [Claude Code](https://claude.ai/code)