### PR TITLE
chore: add codex to the dock

### DIFF
--- a/hosts/darwin/personal/default.nix
+++ b/hosts/darwin/personal/default.nix
@@ -51,6 +51,7 @@ in
       { path = "/Applications/Telegram.app"; }
       { path = "/Applications/Spotify.app"; }
       { path = "/Applications/Linear.app"; }
+      { path = "/Applications/Codex.app"; }
       { path = "${pkgs.ghostty-bin}/Applications/Ghostty.app"; }
       { path = "${pkgs.zed-editor-preview-bin}/Applications/Zed Preview.app"; }
       { path = "/Applications/Anki.app"; }

--- a/hosts/darwin/work/default.nix
+++ b/hosts/darwin/work/default.nix
@@ -48,6 +48,7 @@ in
       { path = "/Applications/Slack.app"; }
       { path = "/Applications/Telegram.app"; }
       { path = "/Applications/Linear.app"; }
+      { path = "/Applications/Codex.app"; }
       { path = "${pkgs.ghostty-bin}/Applications/Ghostty.app"; }
       { path = "${pkgs.zed-editor-preview-bin}/Applications/Zed Preview.app"; }
       { path = "/System/Applications/System Settings.app"; }


### PR DESCRIPTION
## Summary
- Add `/Applications/Codex.app` ahead of Ghostty in the Dock entries for both macOS laptop configurations
- Keep the ordering consistent across personal and work hosts

## Testing
- `nix fmt`
- Evaluated both Darwin Dock entry lists to confirm Codex now appears before Ghostty