### PR TITLE
Fix macos ulimit to unlimited

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -198,7 +198,7 @@
 
       boxPkgs = import nixpkgs {
         system = "x86_64-linux";
-        overlays = overlays;
+        inherit overlays;
         config.allowUnfree = true;
       };
     in

--- a/hosts/darwin/personal/default.nix
+++ b/hosts/darwin/personal/default.nix
@@ -28,6 +28,23 @@ in
   # Let Determinate Nix handle Nix configuration
   nix.enable = false;
 
+  ## Launchd limits
+  launchd = {
+    daemons.ulimit-maxfiles = {
+      command = "/bin/launchctl limit maxfiles unlimited unlimited";
+      serviceConfig = {
+        RunAtLoad = true;
+      };
+    };
+
+    user.agents.ulimit-maxfiles = {
+      command = "/bin/launchctl limit maxfiles unlimited unlimited";
+      serviceConfig = {
+        RunAtLoad = true;
+      };
+    };
+  };
+
   ## Users
   users.users.${user} = {
     uid = 501;

--- a/hosts/darwin/work/default.nix
+++ b/hosts/darwin/work/default.nix
@@ -28,6 +28,23 @@ in
   ## Nix settings
   nix.enable = false;
 
+  ## Launchd limits
+  launchd = {
+    daemons.ulimit-maxfiles = {
+      command = "/bin/launchctl limit maxfiles unlimited unlimited";
+      serviceConfig = {
+        RunAtLoad = true;
+      };
+    };
+
+    user.agents.ulimit-maxfiles = {
+      command = "/bin/launchctl limit maxfiles unlimited unlimited";
+      serviceConfig = {
+        RunAtLoad = true;
+      };
+    };
+  };
+
   ## Users
   users.users.${user} = {
     uid = 501;

--- a/modules/darwin/programs/fish.nix
+++ b/modules/darwin/programs/fish.nix
@@ -1,14 +1,20 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 let
   layoutNu = ../nu/layout.nu;
 in
 {
-  programs.fish.functions.layout = {
-    description = "Set up aerospace window layout (runs nushell layout script)";
-    argumentNames = [ "variant" ];
-    body = ''
-      ${pkgs.nushell}/bin/nu -c "use ${layoutNu} *; layout $variant"
+  programs.fish = {
+    shellInit = lib.mkAfter ''
+      ulimit -n unlimited 2>/dev/null
     '';
+
+    functions.layout = {
+      description = "Set up aerospace window layout (runs nushell layout script)";
+      argumentNames = [ "variant" ];
+      body = ''
+        ${pkgs.nushell}/bin/nu -c "use ${layoutNu} *; layout $variant"
+      '';
+    };
   };
 }

--- a/modules/nixos/services/k3s.nix
+++ b/modules/nixos/services/k3s.nix
@@ -1,5 +1,4 @@
-{ ... }:
-{
+_: {
   services.k3s = {
     enable = true;
     role = "server";


### PR DESCRIPTION
## Summary
- set launchd maxfiles to `unlimited unlimited` on both macOS hosts so the system limit matches the desired shell setting
- add a fish shell init fallback so interactive macOS shells also request an unlimited open-file limit

## Testing
- `nix fmt`
- evaluated both Darwin configurations successfully